### PR TITLE
CB2-7511: Fix VOTT pack after schema changes made to NOP database

### DIFF
--- a/src/main/java/vott/database/TestResultRepository.java
+++ b/src/main/java/vott/database/TestResultRepository.java
@@ -26,6 +26,7 @@ public class TestResultRepository extends AbstractRepository<TestResult>{
                 "preparer_id",
                 "vehicle_class_id",
                 "test_type_id",
+                "testResultId",
                 "testStatus",
                 "reasonForCancellation",
                 "numberOfSeats",
@@ -73,83 +74,85 @@ public class TestResultRepository extends AbstractRepository<TestResult>{
         preparedStatement.setString(5, entity.getPreparerID());
         preparedStatement.setString(6, entity.getVehicleClassID());
         preparedStatement.setString(7, entity.getTestTypeID());
-        preparedStatement.setString(8, entity.getTestStatus());
-        preparedStatement.setString(9, entity.getReasonForCancellation());
-        preparedStatement.setString(10, entity.getNumberOfSeats());
-        preparedStatement.setString(11, entity.getOdometerReading());
-        preparedStatement.setString(12, entity.getOdometerReadingUnits());
-        preparedStatement.setString(13, entity.getCountryOfRegistration());
-        preparedStatement.setString(14, entity.getNoOfAxles());
-        preparedStatement.setString(15, entity.getRegnDate());
-        preparedStatement.setString(16, entity.getFirstUseDate());
-        preparedStatement.setString(17, entity.getCreatedAt());
-        preparedStatement.setString(18, entity.getLastUpdatedAt());
-        preparedStatement.setString(19, entity.getTestCode());
-        preparedStatement.setString(20, entity.getTestNumber());
-        preparedStatement.setString(21, entity.getCertificateNumber());
-        preparedStatement.setString(22, entity.getSecondaryCertificateNumber());
-        preparedStatement.setString(23, entity.getTestExpiryDate());
-        preparedStatement.setString(24, entity.getTestAnniversaryDate());
-        preparedStatement.setString(25, entity.getTestTypeStartTimestamp());
-        preparedStatement.setString(26, entity.getTestTypeEndTimestamp());
-        preparedStatement.setString(27, entity.getNumberOfSeatbeltsFitted());
-        preparedStatement.setString(28, entity.getLastSeatbeltInstallationCheckDate());
-        preparedStatement.setString(29, entity.getSeatbeltInstallationCheckDate());
-        preparedStatement.setString(30, entity.getTestResult());
-        preparedStatement.setString(31, entity.getReasonForAbandoning());
-        preparedStatement.setString(32, entity.getAdditionalNotesRecorded());
-        preparedStatement.setString(33, entity.getAdditionalCommentsForAbandon());
-        preparedStatement.setString(34, entity.getParticulateTrapFitted());
-        preparedStatement.setString(35, entity.getParticulateTrapSerialNumber());
-        preparedStatement.setString(36, entity.getModificationTypeUsed());
-        preparedStatement.setString(37, entity.getSmokeTestKLimitApplied());
-        preparedStatement.setString(38, entity.getCreatedByID());
-        preparedStatement.setString(39, entity.getLastUpdatedByID());
+        preparedStatement.setString(8, entity.getTestResultId());
+        preparedStatement.setString(9, entity.getTestStatus());
+        preparedStatement.setString(10, entity.getReasonForCancellation());
+        preparedStatement.setString(11, entity.getNumberOfSeats());
+        preparedStatement.setString(12, entity.getOdometerReading());
+        preparedStatement.setString(13, entity.getOdometerReadingUnits());
+        preparedStatement.setString(14, entity.getCountryOfRegistration());
+        preparedStatement.setString(15, entity.getNoOfAxles());
+        preparedStatement.setString(16, entity.getRegnDate());
+        preparedStatement.setString(17, entity.getFirstUseDate());
+        preparedStatement.setString(18, entity.getCreatedAt());
+        preparedStatement.setString(19, entity.getLastUpdatedAt());
+        preparedStatement.setString(20, entity.getTestCode());
+        preparedStatement.setString(21, entity.getTestNumber());
+        preparedStatement.setString(22, entity.getCertificateNumber());
+        preparedStatement.setString(23, entity.getSecondaryCertificateNumber());
+        preparedStatement.setString(24, entity.getTestExpiryDate());
+        preparedStatement.setString(25, entity.getTestAnniversaryDate());
+        preparedStatement.setString(26, entity.getTestTypeStartTimestamp());
+        preparedStatement.setString(27, entity.getTestTypeEndTimestamp());
+        preparedStatement.setString(28, entity.getNumberOfSeatbeltsFitted());
+        preparedStatement.setString(29, entity.getLastSeatbeltInstallationCheckDate());
+        preparedStatement.setString(30, entity.getSeatbeltInstallationCheckDate());
+        preparedStatement.setString(31, entity.getTestResult());
+        preparedStatement.setString(32, entity.getReasonForAbandoning());
+        preparedStatement.setString(33, entity.getAdditionalNotesRecorded());
+        preparedStatement.setString(34, entity.getAdditionalCommentsForAbandon());
+        preparedStatement.setString(35, entity.getParticulateTrapFitted());
+        preparedStatement.setString(36, entity.getParticulateTrapSerialNumber());
+        preparedStatement.setString(37, entity.getModificationTypeUsed());
+        preparedStatement.setString(38, entity.getSmokeTestKLimitApplied());
+        preparedStatement.setString(39, entity.getCreatedByID());
+        preparedStatement.setString(40, entity.getLastUpdatedByID());
     }
 
     @Override
     protected void setParametersFull(PreparedStatement preparedStatement, TestResult entity) throws SQLException {
         setParameters(preparedStatement, entity);
 
-        preparedStatement.setString(40, entity.getVehicleID());
-        preparedStatement.setString(41, entity.getFuelEmissionID());
-        preparedStatement.setString(42, entity.getTestStationID());
-        preparedStatement.setString(43, entity.getTesterID());
-        preparedStatement.setString(44, entity.getPreparerID());
-        preparedStatement.setString(45, entity.getVehicleClassID());
-        preparedStatement.setString(46, entity.getTestTypeID());
-        preparedStatement.setString(47, entity.getTestStatus());
-        preparedStatement.setString(48, entity.getReasonForCancellation());
-        preparedStatement.setString(49, entity.getNumberOfSeats());
-        preparedStatement.setString(50, entity.getOdometerReading());
-        preparedStatement.setString(51, entity.getOdometerReadingUnits());
-        preparedStatement.setString(52, entity.getCountryOfRegistration());
-        preparedStatement.setString(53, entity.getNoOfAxles());
-        preparedStatement.setString(54, entity.getRegnDate());
-        preparedStatement.setString(55, entity.getFirstUseDate());
-        preparedStatement.setString(56, entity.getCreatedAt());
-        preparedStatement.setString(57, entity.getLastUpdatedAt());
-        preparedStatement.setString(58, entity.getTestCode());
-        preparedStatement.setString(59, entity.getTestNumber());
-        preparedStatement.setString(60, entity.getCertificateNumber());
-        preparedStatement.setString(61, entity.getSecondaryCertificateNumber());
-        preparedStatement.setString(62, entity.getTestExpiryDate());
-        preparedStatement.setString(63, entity.getTestAnniversaryDate());
-        preparedStatement.setString(64, entity.getTestTypeStartTimestamp());
-        preparedStatement.setString(65, entity.getTestTypeEndTimestamp());
-        preparedStatement.setString(66, entity.getNumberOfSeatbeltsFitted());
-        preparedStatement.setString(67, entity.getLastSeatbeltInstallationCheckDate());
-        preparedStatement.setString(68, entity.getSeatbeltInstallationCheckDate());
-        preparedStatement.setString(69, entity.getTestResult());
-        preparedStatement.setString(70, entity.getReasonForAbandoning());
-        preparedStatement.setString(71, entity.getAdditionalNotesRecorded());
-        preparedStatement.setString(72, entity.getAdditionalCommentsForAbandon());
-        preparedStatement.setString(73, entity.getParticulateTrapFitted());
-        preparedStatement.setString(74, entity.getParticulateTrapSerialNumber());
-        preparedStatement.setString(75, entity.getModificationTypeUsed());
-        preparedStatement.setString(76, entity.getSmokeTestKLimitApplied());
-        preparedStatement.setString(77, entity.getCreatedByID());
-        preparedStatement.setString(78, entity.getLastUpdatedByID());
+        preparedStatement.setString(41, entity.getVehicleID());
+        preparedStatement.setString(42, entity.getFuelEmissionID());
+        preparedStatement.setString(43, entity.getTestStationID());
+        preparedStatement.setString(44, entity.getTesterID());
+        preparedStatement.setString(45, entity.getPreparerID());
+        preparedStatement.setString(46, entity.getVehicleClassID());
+        preparedStatement.setString(47, entity.getTestTypeID());
+        preparedStatement.setString(48, entity.getTestResultId());
+        preparedStatement.setString(49, entity.getTestStatus());
+        preparedStatement.setString(50, entity.getReasonForCancellation());
+        preparedStatement.setString(51, entity.getNumberOfSeats());
+        preparedStatement.setString(52, entity.getOdometerReading());
+        preparedStatement.setString(53, entity.getOdometerReadingUnits());
+        preparedStatement.setString(54, entity.getCountryOfRegistration());
+        preparedStatement.setString(55, entity.getNoOfAxles());
+        preparedStatement.setString(56, entity.getRegnDate());
+        preparedStatement.setString(57, entity.getFirstUseDate());
+        preparedStatement.setString(58, entity.getCreatedAt());
+        preparedStatement.setString(59, entity.getLastUpdatedAt());
+        preparedStatement.setString(60, entity.getTestCode());
+        preparedStatement.setString(61, entity.getTestNumber());
+        preparedStatement.setString(62, entity.getCertificateNumber());
+        preparedStatement.setString(63, entity.getSecondaryCertificateNumber());
+        preparedStatement.setString(64, entity.getTestExpiryDate());
+        preparedStatement.setString(65, entity.getTestAnniversaryDate());
+        preparedStatement.setString(66, entity.getTestTypeStartTimestamp());
+        preparedStatement.setString(67, entity.getTestTypeEndTimestamp());
+        preparedStatement.setString(68, entity.getNumberOfSeatbeltsFitted());
+        preparedStatement.setString(69, entity.getLastSeatbeltInstallationCheckDate());
+        preparedStatement.setString(70, entity.getSeatbeltInstallationCheckDate());
+        preparedStatement.setString(71, entity.getTestResult());
+        preparedStatement.setString(72, entity.getReasonForAbandoning());
+        preparedStatement.setString(73, entity.getAdditionalNotesRecorded());
+        preparedStatement.setString(74, entity.getAdditionalCommentsForAbandon());
+        preparedStatement.setString(75, entity.getParticulateTrapFitted());
+        preparedStatement.setString(76, entity.getParticulateTrapSerialNumber());
+        preparedStatement.setString(77, entity.getModificationTypeUsed());
+        preparedStatement.setString(78, entity.getSmokeTestKLimitApplied());
+        preparedStatement.setString(79, entity.getCreatedByID());
+        preparedStatement.setString(80, entity.getLastUpdatedByID());
     }
 
     @Override
@@ -163,6 +166,7 @@ public class TestResultRepository extends AbstractRepository<TestResult>{
         tr.setPreparerID(rs.getString("preparer_id"));
         tr.setVehicleClassID(rs.getString("vehicle_class_id"));
         tr.setTestTypeID(rs.getString("test_type_id"));
+        tr.setTestResultId(rs.getString("testResultId"));
         tr.setTestStatus(rs.getString("testStatus"));
         tr.setReasonForCancellation(rs.getString("reasonForCancellation"));
         tr.setNumberOfSeats(rs.getString("numberOfSeats"));

--- a/src/main/java/vott/database/seeddata/SeedData.java
+++ b/src/main/java/vott/database/seeddata/SeedData.java
@@ -106,6 +106,7 @@ public class SeedData {
         tr.setPreparerID(String.valueOf(preparerPK));
         tr.setVehicleClassID(String.valueOf(vehicleClassPK));
         tr.setTestTypeID(String.valueOf(testTypePK));
+        tr.setTestResultId("1111-1111-1111-1111");
         tr.setTestStatus("Test Pass");
         tr.setReasonForCancellation("Automation Test Run");
         tr.setNumberOfSeats("3");

--- a/src/main/java/vott/models/dao/TestResult.java
+++ b/src/main/java/vott/models/dao/TestResult.java
@@ -12,6 +12,7 @@ public class TestResult {
     private String preparerID;
     private String vehicleClassID;
     private String testTypeID;
+    private String testResultId;
     private String testStatus;
     private String reasonForCancellation;
     private String numberOfSeats;

--- a/src/main/java/vott/models/dto/enquiry/TestResult.java
+++ b/src/main/java/vott/models/dto/enquiry/TestResult.java
@@ -43,6 +43,9 @@ public class TestResult {
   @SerializedName("customDefect")
   private CustomDefects customDefect = null;
 
+  @SerializedName("testResultId")
+  private String testResultId = null;
+
   @SerializedName("testStatus")
   private String testStatus = null;
 
@@ -265,6 +268,23 @@ public class TestResult {
 
   public void setTestStatus(String testStatus) {
     this.testStatus = testStatus;
+  }
+
+  public TestResult testResultId(String testResultId) {
+    this.testResultId = testResultId;
+    return this;
+  }
+
+   /**
+   * Get testResultId
+   * @return testResultId
+  **/
+  public String getTestResultId() {
+    return testResultId;
+  }
+
+  public void setTestResultId(String testResultId) {
+    this.testResultId = testResultId;
   }
 
   public TestResult reasonForCancellation(String reasonForCancellation) {
@@ -869,6 +889,7 @@ public class TestResult {
         Objects.equals(this.vehicleClass, testResult.vehicleClass) &&
         Objects.equals(this.testType, testResult.testType) &&
         Objects.equals(this.customDefect, testResult.customDefect) &&
+        Objects.equals(this.testResultId, testResult.testResultId) &&
         Objects.equals(this.testStatus, testResult.testStatus) &&
         Objects.equals(this.reasonForCancellation, testResult.reasonForCancellation) &&
         Objects.equals(this.numberOfSeats, testResult.numberOfSeats) &&
@@ -908,7 +929,7 @@ public class TestResult {
 
   @Override
   public int hashCode() {
-    return Objects.hash(fuelEmission, testStation, tester, vehicleClass, testType, customDefect, testStatus, reasonForCancellation, numberOfSeats, odometerReading, odometerReadingUnits, countryOfRegistration, noOfAxles, regnDate, firstUseDate, createdAt, lastUpdatedAt, testCode, testNumber, certificateNumber, secondaryCertificateNumber, testExpiryDate, testAnniversaryDate, testTypeStartTimestamp, testTypeEndTimestamp, numberOfSeatbeltsFitted, lastSeatbeltInstallationCheckDate, seatbeltInstallationCheckDate, testResult, reasonForAbandoning, additionalNotesRecorded, additionalCommentsForAbandon, particulateTrapFitted, particulateTrapSerialNumber, modificationTypeUsed, smokeTestKLimitApplied, createdById, createdByName, lastUpdatedById, lastUpdatedByName, defects);
+    return Objects.hash(fuelEmission, testStation, tester, vehicleClass, testType, customDefect, testResultId, testStatus, reasonForCancellation, numberOfSeats, odometerReading, odometerReadingUnits, countryOfRegistration, noOfAxles, regnDate, firstUseDate, createdAt, lastUpdatedAt, testCode, testNumber, certificateNumber, secondaryCertificateNumber, testExpiryDate, testAnniversaryDate, testTypeStartTimestamp, testTypeEndTimestamp, numberOfSeatbeltsFitted, lastSeatbeltInstallationCheckDate, seatbeltInstallationCheckDate, testResult, reasonForAbandoning, additionalNotesRecorded, additionalCommentsForAbandon, particulateTrapFitted, particulateTrapSerialNumber, modificationTypeUsed, smokeTestKLimitApplied, createdById, createdByName, lastUpdatedById, lastUpdatedByName, defects);
   }
 
 
@@ -923,6 +944,7 @@ public class TestResult {
     sb.append("    vehicleClass: ").append(toIndentedString(vehicleClass)).append("\n");
     sb.append("    testType: ").append(toIndentedString(testType)).append("\n");
     sb.append("    customDefect: ").append(toIndentedString(customDefect)).append("\n");
+    sb.append("    testResultId: ").append(toIndentedString(testResultId)).append("\n");
     sb.append("    testStatus: ").append(toIndentedString(testStatus)).append("\n");
     sb.append("    reasonForCancellation: ").append(toIndentedString(reasonForCancellation)).append("\n");
     sb.append("    numberOfSeats: ").append(toIndentedString(numberOfSeats)).append("\n");

--- a/src/test/java/vott/database/AxlesRepositoryTest.java
+++ b/src/test/java/vott/database/AxlesRepositoryTest.java
@@ -85,7 +85,7 @@ public class AxlesRepositoryTest {
         }
         tyreRepository.delete(tyrePK);
         if (tyre2PK != null){
-            technicalRecordRepository.delete(tyre2PK);
+            tyreRepository.delete(tyre2PK);
         }
         vehicleRepository.delete(vehiclePK);
         makeModelRepository.delete(makeModelPK);

--- a/src/test/java/vott/database/TestDefectRepositoryTest.java
+++ b/src/test/java/vott/database/TestDefectRepositoryTest.java
@@ -144,7 +144,7 @@ public class TestDefectRepositoryTest {
     @Test
     public void upsertingNewTestResultIDReturnsDifferentPk() {
         TestResult tr2 = SeedData.newTestTestResult(vehiclePK, fuelEmissionPK, testStationPK, testerPK, preparerPK, vehicleClassPK, testTypePK, identityPK);
-        tr2.setCreatedAt("2022-01-01 00:00:00");
+        tr2.setTestResultId("2222-2222-2222-2222");
         testResult2PK = testResultRepository.fullUpsert(tr2);
 
         TestDefect td1 = SeedData.newTestTestDefect(testResultPK, testDefectPK,locationPK);

--- a/src/test/java/vott/database/TestResultRepositoryTest.java
+++ b/src/test/java/vott/database/TestResultRepositoryTest.java
@@ -136,14 +136,10 @@ public class TestResultRepositoryTest {
     @WithTag("Vott")
     @Title("VOTT-8 - AC1 - TC51 - Testing test result unique index compound key")
     @Test
-    public void upsertingNewTestTypeIDReturnsDifferentPk() {
-        TestType tt2 = SeedData.newTestTestType();
-        tt2.setTestTypeClassification("Auto Test Type");
-
-        testType2PK = testTypeRepository.partialUpsert(tt2);
-
+    public void upsertingNewTestNumberReturnsDifferentPk() {
         TestResult tr1 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
-        TestResult tr2 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testType2PK, identityPK);
+        TestResult tr2 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
+        tr2.setTestNumber("B222A111");
 
         int primaryKey1 = testResultRepository.fullUpsert(tr1);
         int primaryKey2 = testResultRepository.fullUpsert(tr2);
@@ -157,11 +153,10 @@ public class TestResultRepositoryTest {
     @WithTag("Vott")
     @Title("VOTT-8 - AC1 - TC52 - Testing test result unique index compound key")
     @Test
-    public void upsertingNewCreatedAtReturnsDifferentPk() {
+    public void upsertingNewTestResultIdReturnsDifferentPk() {
         TestResult tr1 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
-
         TestResult tr2 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
-        tr2.setCreatedAt("2021-12-31 00:00:00");
+        tr2.setTestResultId("2222-2222-2222-2222");
 
         int primaryKey1 = testResultRepository.fullUpsert(tr1);
         int primaryKey2 = testResultRepository.fullUpsert(tr2);
@@ -175,11 +170,27 @@ public class TestResultRepositoryTest {
     @WithTag("Vott")
     @Title("VOTT-8 - AC1 - TC53 - Testing test result unique index compound key")
     @Test
+    public void upsertingNewTestTypeEndTimestampReturnsDifferentPk() {
+        TestResult tr1 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
+        TestResult tr2 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
+        tr2.setTestTypeEndTimestamp("2022-01-02 00:00:00");
+
+        int primaryKey1 = testResultRepository.fullUpsert(tr1);
+        int primaryKey2 = testResultRepository.fullUpsert(tr2);
+
+        deleteOnExit.add(primaryKey1);
+        deleteOnExit.add(primaryKey2);
+
+        assertNotEquals(primaryKey1, primaryKey2);
+    }
+
+    @WithTag("Vott")
+    @Title("VOTT-8 - AC1 - TC54 - Testing test result unique index compound key")
+    @Test
     public void upsertingIdenticalIndexValuesReturnsSamePk() {
         TestResult tr1 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
-
         TestResult tr2 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
-        tr2.setTestNumber("55555");
+        tr2.setTestResult("Test Fail");
 
         int primaryKey1 = testResultRepository.fullUpsert(tr1);
         int primaryKey2 = testResultRepository.fullUpsert(tr2);


### PR DESCRIPTION
## Description

As part of the NOP Rebuild work there has been some schema changes to the MySQL database. These changes need to be reflected in the VOTT regression pack.

Related issue: [CB2-7511](https://dvsa.atlassian.net/browse/CB2-7511)

## Evidence of Completion
The code changes were deployed to the noptest-1 environment in AWS.
The run completed with a 100% success rate.
https://jenkins.cvs.dvsacloud.uk/job/UPDATE__BRANCH/job/job_feature_test_backend_vott/158/
![image](https://user-images.githubusercontent.com/13391709/218431053-1797ab11-37b8-4e5b-932d-38e26d63bb4b.png)

