### PR TITLE
Feature/cb2 10415

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,11 +99,11 @@
             <artifactId>serenity-maven-plugin</artifactId>
             <version>${serenity.version}</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.mysql/mysql-connector-j -->
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.33</version>
-            <scope>test</scope>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/src/main/java/vott/api/TestResultAPI.java
+++ b/src/main/java/vott/api/TestResultAPI.java
@@ -30,7 +30,7 @@ public class TestResultAPI {
                     .body(testResultJson)
                     .post().thenReturn();
             statusCode = response.statusCode();
-            //System.out.print(response.getBody());
+            System.out.print(response.getBody().toString());
             tries++;
         } while (statusCode >= 500 && tries < maxRetries);
     }

--- a/src/main/java/vott/api/TestResultAPI.java
+++ b/src/main/java/vott/api/TestResultAPI.java
@@ -15,7 +15,7 @@ public class TestResultAPI {
     private static final String apiKey = configuration.getApiKeys().getEnquiryServiceApiKey();
     private static final Gson gson = GsonInstance.get();
 
-    public static void postTestResult(CompleteTestResults testResult, String token){
+    public static void postTestResult(CompleteTestResults testResult, String token) {
         RESTAssuredBaseURI();
 
         String testResultJson = gson.toJson(testResult);
@@ -30,12 +30,12 @@ public class TestResultAPI {
                     .body(testResultJson)
                     .post().thenReturn();
             statusCode = response.statusCode();
-            System.out.print(response.getBody().toString());
+            //System.out.print(response.getBody().toString());
             tries++;
         } while (statusCode >= 500 && tries < maxRetries);
     }
 
-    private static void RESTAssuredBaseURI(){
+    private static void RESTAssuredBaseURI() {
         RestAssured.baseURI = configuration.getApiProperties().getBranchSpecificUrl() + "/test-results";
     }
 

--- a/src/main/java/vott/api/VehiclesAPI.java
+++ b/src/main/java/vott/api/VehiclesAPI.java
@@ -16,7 +16,7 @@ public class VehiclesAPI {
     private static final String apiKey = configuration.getApiKeys().getEnquiryServiceApiKey();
     private static final Gson gson = GsonInstance.get();
 
-    public static void postVehicleTechnicalRecord(TechRecordPOST techRecord, String token){
+    public static void postVehicleTechnicalRecord(TechRecordPOST techRecord, String token) {
         RESTAssuredBaseURI();
 
         String techRecordJson = gson.toJson(techRecord);
@@ -31,12 +31,12 @@ public class VehiclesAPI {
                     .body(techRecordJson)
                     .post().thenReturn();
             statusCode = response.statusCode();
-            System.out.print(response.getBody().toString());
+            //System.out.print(response.getBody().toString());
             tries++;
         } while (statusCode >= 500 && tries < maxRetries);
     }
 
-    private static void RESTAssuredBaseURI(){
+    private static void RESTAssuredBaseURI() {
         RestAssured.baseURI = configuration.getApiProperties().getBranchSpecificUrl() + "/vehicles";
     }
 

--- a/src/main/java/vott/api/VehiclesAPI.java
+++ b/src/main/java/vott/api/VehiclesAPI.java
@@ -31,6 +31,7 @@ public class VehiclesAPI {
                     .body(techRecordJson)
                     .post().thenReturn();
             statusCode = response.statusCode();
+            System.out.print(response.getBody().toString());
             tries++;
         } while (statusCode >= 500 && tries < maxRetries);
     }

--- a/src/main/java/vott/database/AbstractRepository.java
+++ b/src/main/java/vott/database/AbstractRepository.java
@@ -22,8 +22,7 @@ public abstract class AbstractRepository<T> {
         try (Connection connection = connectionFactory.getConnection()) {
             PreparedStatement preparedStatement = connection.prepareStatement(
                     sqlGenerator.generatePartialUpsertSql(getTableDetails()),
-                    //Statement.RETURN_GENERATED_KEYS
-                    new String[]{"id"}
+                    Statement.RETURN_GENERATED_KEYS
             );
 
             setParameters(preparedStatement, entity);

--- a/src/main/java/vott/database/AbstractRepository.java
+++ b/src/main/java/vott/database/AbstractRepository.java
@@ -1,6 +1,5 @@
 package vott.database;
 
-import com.github.rjeschke.txtmark.Run;
 import vott.database.connection.ConnectionFactory;
 import vott.database.sqlgeneration.SqlGenerator;
 import vott.database.sqlgeneration.TableDetails;
@@ -23,7 +22,8 @@ public abstract class AbstractRepository<T> {
         try (Connection connection = connectionFactory.getConnection()) {
             PreparedStatement preparedStatement = connection.prepareStatement(
                     sqlGenerator.generatePartialUpsertSql(getTableDetails()),
-                    Statement.RETURN_GENERATED_KEYS
+                    //Statement.RETURN_GENERATED_KEYS
+                    new String[]{"id"}
             );
 
             setParameters(preparedStatement, entity);
@@ -38,8 +38,63 @@ public abstract class AbstractRepository<T> {
     }
 
 
+    public int fullUpsertIfNotExists(T entity) {
+
+        int idReturned = -1;
+
+        //TODO change the sql to use select statement based on if the table has a fingerprint or not
+        //TODO implement the finger print columns into each concrete repository class
+        //TODO add a definition of the fingerprint column name for each table to TableDetails object
+
+        try (Connection connection = connectionFactory.getConnection()) {
+
+            //do a select based on table fingerprint
+            PreparedStatement preparedStatementSelect = connection.prepareStatement(
+                    sqlGenerator.generateSelectByFingerprint(getFingerPrintTableDetails()),
+                    Statement.RETURN_GENERATED_KEYS
+            );
+
+            setFingerprintParameters(preparedStatementSelect, entity);
+            ResultSet selectRS = preparedStatementSelect.executeQuery();
+
+            //should only ever have one row in result set
+            while (selectRS.next()) {
+                //set id to return to one returned from select query
+                idReturned = selectRS.getInt("id");
+            }
+
+            //upsert data
+            PreparedStatement preparedStatement = connection.prepareStatement(
+                    sqlGenerator.generateFullUpsertSql(getTableDetails()),
+                    Statement.RETURN_GENERATED_KEYS
+            );
+
+            setParametersFull(preparedStatement, entity);
+            //capture id returned from upsert
+            //in RDS v8 an upsert with no change does not return a generated key
+            int upsertIdReturned = upsert(
+                    preparedStatement,
+                    entity
+            );
+
+            //added to ensure id is returned from select if nothing is returned by upsert
+            if (upsertIdReturned != -1) {
+                idReturned = upsertIdReturned;
+            }
+
+
+            return idReturned;
+
+
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public int fullUpsert(T entity) {
         try (Connection connection = connectionFactory.getConnection()) {
+
+            // String[] columns = {"id"};
             PreparedStatement preparedStatement = connection.prepareStatement(
                     sqlGenerator.generateFullUpsertSql(getTableDetails()),
                     Statement.RETURN_GENERATED_KEYS
@@ -57,7 +112,7 @@ public abstract class AbstractRepository<T> {
         }
     }
 
-    public void fullUpsertWithoutID(T entity) throws RuntimeException,SQLException {
+    public void fullUpsertWithoutID(T entity) throws RuntimeException, SQLException {
         try (Connection connection = connectionFactory.getConnection()) {
             PreparedStatement preparedStatement = connection.prepareStatement(
                     sqlGenerator.generateFullUpsertSqlWithoutID(getTableDetails()),
@@ -135,35 +190,49 @@ public abstract class AbstractRepository<T> {
 
     protected abstract TableDetails getTableDetails();
 
+    protected abstract TableDetails getFingerPrintTableDetails();
+
+    protected abstract void setFingerprintParameters(PreparedStatement preparedStatement, T entity) throws SQLException;
+
     protected abstract void setParameters(PreparedStatement preparedStatement, T entity) throws SQLException;
 
     protected abstract void setParametersFull(PreparedStatement preparedStatement, T entity) throws SQLException;
 
     protected abstract T mapToEntity(ResultSet rs) throws SQLException;
 
-    private int upsert(PreparedStatement preparedStatement, T entity) throws SQLException {
-        int affectedRows = preparedStatement.executeUpdate();
+    private int upsert(PreparedStatement preparedStatement, T entity) {
 
-        if (affectedRows != 1 && affectedRows != 2) {
-            throw new RuntimeException("Expected either 1 (INSERT) or 2 (UPDATE) affected rows, got " + affectedRows);
+
+        try {
+            int affectedRows = preparedStatement.executeUpdate();
+
+            if (affectedRows != 1 && affectedRows != 2) {
+                throw new RuntimeException("Expected either 1 (INSERT) or 2 (UPDATE) affected rows, got " + affectedRows);
+            }
+
+            ResultSet rs = preparedStatement.getGeneratedKeys();
+
+            //Get Generated keys can return 2 values when a full upsert is executed, this is a known issue with JDBC and mysql - https://bugs.mysql.com/bug.php?id=90688
+            //Since RDS8 this can also return an empty resultSet if 0 rows are updated
+            List<Integer> generatedKeys = new ArrayList<>();
+            if (rs.getMetaData().getColumnCount() != 1) {
+                throw new RuntimeException("Expected exactly 1 column in generated keys ResultSet, got " + rs.getMetaData().getColumnCount());
+            }
+
+            while (rs.next()) {
+                generatedKeys.add(rs.getInt(1));
+
+            }
+
+            if (generatedKeys.size() != 1 && generatedKeys.size() != 2) {
+                //to ensure there is always a value in generatedKeys(0)
+                generatedKeys.add(-1);
+            }
+
+            return generatedKeys.get(0);
+
+        } catch (SQLException e) {
+            return -1;
         }
-
-        ResultSet rs = preparedStatement.getGeneratedKeys();
-        //Get Generated keys can return 2 values when a full upsert is ran, this is a known issue with JDBC and mysql - https://bugs.mysql.com/bug.php?id=90688
-
-        List<Integer> generatedKeys = new ArrayList<>();
-
-        if (rs.getMetaData().getColumnCount() != 1) {
-            throw new RuntimeException("Expected exactly 1 column in generated keys ResultSet, got " + rs.getMetaData().getColumnCount());
-        }
-
-        while (rs.next()) {
-            generatedKeys.add(rs.getInt(1));
-        }
-
-        if (generatedKeys.size() != 1 && generatedKeys.size() != 2) { //.size == 2 allowed due to bug linked in comments related to generated keys above
-            throw new RuntimeException("Expected exactly 1 generated key, got " + generatedKeys.size());
-        }
-        return generatedKeys.get(0);
     }
 }

--- a/src/main/java/vott/database/AbstractRepository.java
+++ b/src/main/java/vott/database/AbstractRepository.java
@@ -92,8 +92,6 @@ public abstract class AbstractRepository<T> {
 
     public int fullUpsert(T entity) {
         try (Connection connection = connectionFactory.getConnection()) {
-
-            // String[] columns = {"id"};
             PreparedStatement preparedStatement = connection.prepareStatement(
                     sqlGenerator.generateFullUpsertSql(getTableDetails()),
                     Statement.RETURN_GENERATED_KEYS

--- a/src/main/java/vott/database/AuthIntoServicesRepository.java
+++ b/src/main/java/vott/database/AuthIntoServicesRepository.java
@@ -28,6 +28,16 @@ public class AuthIntoServicesRepository extends AbstractRepository<AuthIntoServi
         }
 
         @Override
+        protected TableDetails getFingerPrintTableDetails() {
+                return null;
+        }
+
+        @Override
+        protected void setFingerprintParameters(PreparedStatement preparedStatement, AuthIntoServices entity) throws SQLException {
+
+        }
+
+        @Override
         protected void setParameters(PreparedStatement preparedStatement, AuthIntoServices entity) throws SQLException {
                 // 1-indexed
                 preparedStatement.setString(1, entity.getId());

--- a/src/main/java/vott/database/AxleSpacingRepository.java
+++ b/src/main/java/vott/database/AxleSpacingRepository.java
@@ -27,6 +27,16 @@ public class AxleSpacingRepository extends AbstractRepository<AxleSpacing> {
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, AxleSpacing entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, AxleSpacing entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getTechnicalRecordID());

--- a/src/main/java/vott/database/AxlesRepository.java
+++ b/src/main/java/vott/database/AxlesRepository.java
@@ -37,6 +37,16 @@ public class AxlesRepository extends AbstractRepository<Axles> {
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, Axles entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, Axles entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getTechnicalRecordID());

--- a/src/main/java/vott/database/ContactDetailsRepository.java
+++ b/src/main/java/vott/database/ContactDetailsRepository.java
@@ -34,6 +34,16 @@ public class ContactDetailsRepository extends AbstractRepository<ContactDetails>
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, ContactDetails entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, ContactDetails entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getName());

--- a/src/main/java/vott/database/CustomDefectRepository.java
+++ b/src/main/java/vott/database/CustomDefectRepository.java
@@ -28,6 +28,16 @@ public class CustomDefectRepository extends AbstractRepository<CustomDefect> {
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, CustomDefect entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, CustomDefect entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getTestResultID());

--- a/src/main/java/vott/database/DefectRepository.java
+++ b/src/main/java/vott/database/DefectRepository.java
@@ -34,6 +34,16 @@ public class DefectRepository extends AbstractRepository<Defect> {
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, Defect entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, Defect entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getImNumber());

--- a/src/main/java/vott/database/EVLViewRepository.java
+++ b/src/main/java/vott/database/EVLViewRepository.java
@@ -25,6 +25,16 @@ public class EVLViewRepository extends AbstractRepository<EVLView> {
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, EVLView entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, EVLView entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getTestExpiryDate());

--- a/src/main/java/vott/database/FuelEmissionRepository.java
+++ b/src/main/java/vott/database/FuelEmissionRepository.java
@@ -28,6 +28,16 @@ public class FuelEmissionRepository extends AbstractRepository<FuelEmission> {
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, FuelEmission entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, FuelEmission entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getModTypeCode());

--- a/src/main/java/vott/database/IdentityRepository.java
+++ b/src/main/java/vott/database/IdentityRepository.java
@@ -29,6 +29,16 @@ public class IdentityRepository extends AbstractRepository<Identity>{
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, Identity entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, Identity entity) throws SQLException {
         preparedStatement.setString(1, entity.getIdentityID());
         preparedStatement.setString(2, entity.getName());

--- a/src/main/java/vott/database/LocationRepository.java
+++ b/src/main/java/vott/database/LocationRepository.java
@@ -31,6 +31,16 @@ public class LocationRepository extends AbstractRepository<Location> {
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, Location entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, Location entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getVertical());

--- a/src/main/java/vott/database/MakeModelRepository.java
+++ b/src/main/java/vott/database/MakeModelRepository.java
@@ -34,6 +34,16 @@ public class MakeModelRepository extends AbstractRepository<MakeModel>{
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, MakeModel entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, MakeModel entity) throws SQLException {
         preparedStatement.setString(1, entity.getMake());
         preparedStatement.setString(2, entity.getModel());

--- a/src/main/java/vott/database/MicrofilmRepository.java
+++ b/src/main/java/vott/database/MicrofilmRepository.java
@@ -28,6 +28,16 @@ public class MicrofilmRepository extends AbstractRepository<Microfilm> {
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, Microfilm entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, Microfilm entity) throws SQLException {
         preparedStatement.setString(1, entity.getTechnicalRecordID());
         preparedStatement.setString(2, entity.getMicrofilmDocumentType());

--- a/src/main/java/vott/database/PSVBrakesRepository.java
+++ b/src/main/java/vott/database/PSVBrakesRepository.java
@@ -38,6 +38,16 @@ public class PSVBrakesRepository extends AbstractRepository<PSVBrakes>{
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, PSVBrakes entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, PSVBrakes entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getTechnicalRecordID());

--- a/src/main/java/vott/database/PlateRepository.java
+++ b/src/main/java/vott/database/PlateRepository.java
@@ -29,6 +29,16 @@ public class PlateRepository extends AbstractRepository<Plate> {
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, Plate entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, Plate entity) throws SQLException {
 
         // 1-indexed

--- a/src/main/java/vott/database/PreparerRepository.java
+++ b/src/main/java/vott/database/PreparerRepository.java
@@ -26,6 +26,16 @@ public class PreparerRepository extends AbstractRepository<Preparer> {
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, Preparer entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, Preparer entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getPreparerID());

--- a/src/main/java/vott/database/TFLViewRepository.java
+++ b/src/main/java/vott/database/TFLViewRepository.java
@@ -31,6 +31,16 @@ public class TFLViewRepository extends AbstractRepository<TFLView> {
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, TFLView entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, TFLView entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getVrm());

--- a/src/main/java/vott/database/TechnicalRecordRepository.java
+++ b/src/main/java/vott/database/TechnicalRecordRepository.java
@@ -108,6 +108,16 @@ public class TechnicalRecordRepository extends AbstractRepository<TechnicalRecor
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, TechnicalRecord entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, TechnicalRecord entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getVehicleID());

--- a/src/main/java/vott/database/TestDefectRepository.java
+++ b/src/main/java/vott/database/TestDefectRepository.java
@@ -30,6 +30,16 @@ public class TestDefectRepository extends AbstractRepository<TestDefect>{
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, TestDefect entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, TestDefect entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getTestResultID());

--- a/src/main/java/vott/database/TestResultRepository.java
+++ b/src/main/java/vott/database/TestResultRepository.java
@@ -82,10 +82,10 @@ public class TestResultRepository extends AbstractRepository<TestResult> {
     protected void setFingerprintParameters(PreparedStatement preparedStatement, TestResult entity) throws SQLException {
 
         String testNumber = entity.getTestNumber();
-        System.out.println(testNumber);
+        //System.out.println(testNumber);
         preparedStatement.setString(1, testNumber);
         String testEndTimestamp = entity.getTestTypeEndTimestamp();
-        System.out.println(testEndTimestamp);
+        //System.out.println(testEndTimestamp);
         preparedStatement.setString(2, testEndTimestamp);
     }
 

--- a/src/main/java/vott/database/TestResultRepository.java
+++ b/src/main/java/vott/database/TestResultRepository.java
@@ -2,23 +2,24 @@ package vott.database;
 
 
 import vott.database.connection.ConnectionFactory;
-import vott.models.dao.TestResult;
 import vott.database.sqlgeneration.TableDetails;
+import vott.models.dao.TestResult;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-public class TestResultRepository extends AbstractRepository<TestResult>{
-    public TestResultRepository(ConnectionFactory connectionFactory) { super(connectionFactory); }
+public class TestResultRepository extends AbstractRepository<TestResult> {
+    public TestResultRepository(ConnectionFactory connectionFactory) {
+        super(connectionFactory);
+    }
 
     @Override
     protected TableDetails getTableDetails() {
 
         TableDetails tableDetails = new TableDetails();
-
         tableDetails.setTableName("test_result");
-        tableDetails.setColumnNames(new String[] {
+        tableDetails.setColumnNames(new String[]{
                 "vehicle_id",
                 "fuel_emission_id",
                 "test_station_id",
@@ -62,6 +63,30 @@ public class TestResultRepository extends AbstractRepository<TestResult>{
         });
 
         return tableDetails;
+    }
+
+
+    protected TableDetails getFingerPrintTableDetails() {
+
+        TableDetails tableDetails = new TableDetails();
+
+        tableDetails.setTableName("test_result");
+        tableDetails.setColumnNames(new String[]{
+                "testNumber",
+                "testTypeEndTimestamp",
+        });
+
+        return tableDetails;
+    }
+
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, TestResult entity) throws SQLException {
+
+        String testNumber = entity.getTestNumber();
+        System.out.println(testNumber);
+        preparedStatement.setString(1, testNumber);
+        String testEndTimestamp = entity.getTestTypeEndTimestamp();
+        System.out.println(testEndTimestamp);
+        preparedStatement.setString(2, testEndTimestamp);
     }
 
     @Override
@@ -202,4 +227,5 @@ public class TestResultRepository extends AbstractRepository<TestResult>{
 
         return tr;
     }
+
 }

--- a/src/main/java/vott/database/TestStationRepository.java
+++ b/src/main/java/vott/database/TestStationRepository.java
@@ -24,6 +24,16 @@ public class TestStationRepository extends AbstractRepository<TestStation> {
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, TestStation entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, TestStation entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getPNumber());

--- a/src/main/java/vott/database/TestTypeRepository.java
+++ b/src/main/java/vott/database/TestTypeRepository.java
@@ -26,6 +26,16 @@ public class TestTypeRepository extends AbstractRepository<TestType> {
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, TestType entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, TestType entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getTestTypeClassification());

--- a/src/main/java/vott/database/TesterRepository.java
+++ b/src/main/java/vott/database/TesterRepository.java
@@ -27,6 +27,16 @@ public class TesterRepository extends AbstractRepository<Tester> {
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, Tester entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, Tester entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getStaffID());

--- a/src/main/java/vott/database/TyreRepository.java
+++ b/src/main/java/vott/database/TyreRepository.java
@@ -31,6 +31,16 @@ public class TyreRepository extends AbstractRepository<Tyre>
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, Tyre entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, Tyre entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getTyreSize());

--- a/src/main/java/vott/database/VehicleClassRepository.java
+++ b/src/main/java/vott/database/VehicleClassRepository.java
@@ -30,6 +30,16 @@ public class VehicleClassRepository extends AbstractRepository<VehicleClass>{
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, VehicleClass entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, VehicleClass entity) throws SQLException {
         preparedStatement.setString(1, entity.getCode());
         preparedStatement.setString(2, entity.getDescription());

--- a/src/main/java/vott/database/VehicleRepository.java
+++ b/src/main/java/vott/database/VehicleRepository.java
@@ -30,6 +30,16 @@ public class VehicleRepository extends AbstractRepository<Vehicle> {
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, Vehicle entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, Vehicle entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getSystemNumber());

--- a/src/main/java/vott/database/VehicleSubclassRepository.java
+++ b/src/main/java/vott/database/VehicleSubclassRepository.java
@@ -27,6 +27,16 @@ public class VehicleSubclassRepository extends AbstractRepository<VehicleSubclas
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, VehicleSubclass entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, VehicleSubclass entity) throws SQLException {
         preparedStatement.setString(1, entity.getVehicleClassID());
         preparedStatement.setString(2, entity.getSubclass());

--- a/src/main/java/vott/database/VtEVLAdditionsRepository.java
+++ b/src/main/java/vott/database/VtEVLAdditionsRepository.java
@@ -25,6 +25,16 @@ public class VtEVLAdditionsRepository extends AbstractRepository<VtEVLAdditions>
     }
 
     @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, VtEVLAdditions entity) throws SQLException {
+
+    }
+
+    @Override
     protected void setParameters(PreparedStatement preparedStatement, VtEVLAdditions entity) throws SQLException {
         // 1-indexed
         preparedStatement.setString(1, entity.getVrmTrmID());

--- a/src/main/java/vott/database/VtEvlCvsRemovedRepository.java
+++ b/src/main/java/vott/database/VtEvlCvsRemovedRepository.java
@@ -27,6 +27,17 @@ public class VtEvlCvsRemovedRepository extends AbstractRepository<VtEvlCvsRemove
         });
         return tableDetails;
     }
+
+    @Override
+    protected TableDetails getFingerPrintTableDetails() {
+        return null;
+    }
+
+    @Override
+    protected void setFingerprintParameters(PreparedStatement preparedStatement, VtEvlCvsRemoved entity) throws SQLException {
+
+    }
+
     @Override
     protected void setParameters(PreparedStatement preparedStatement, VtEvlCvsRemoved entity) throws SQLException {
         // 1-indexed

--- a/src/main/java/vott/database/connection/ConnectionFactory.java
+++ b/src/main/java/vott/database/connection/ConnectionFactory.java
@@ -6,6 +6,7 @@ import vott.config.VottConfiguration;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Properties;
 
 @RequiredArgsConstructor
 public class ConnectionFactory {
@@ -13,6 +14,17 @@ public class ConnectionFactory {
     private final VottConfiguration configuration;
 
     public Connection getConnection() throws SQLException {
+
+//        Properties connectionProps = new Properties();
+//        connectionProps.put("user", configuration.getDatabaseProperties().getUsername());
+//        connectionProps.put("password", configuration.getDatabaseProperties().getPassword());
+//        //connectionProps.put("useAffectedRows", true);
+//        connectionProps.put("compensateOnDuplicateKeyUpdateCounts", true);
+//
+//
+//        Connection newConnection = DriverManager.getConnection(configuration.getDatabaseProperties().toJdbcUrl(),connectionProps);
+ //       return newConnection;
+
         return DriverManager.getConnection(
             configuration.getDatabaseProperties().toJdbcUrl(),
             configuration.getDatabaseProperties().getUsername(),

--- a/src/main/java/vott/database/connection/ConnectionFactory.java
+++ b/src/main/java/vott/database/connection/ConnectionFactory.java
@@ -6,7 +6,6 @@ import vott.config.VottConfiguration;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.Properties;
 
 @RequiredArgsConstructor
 public class ConnectionFactory {
@@ -15,20 +14,10 @@ public class ConnectionFactory {
 
     public Connection getConnection() throws SQLException {
 
-//        Properties connectionProps = new Properties();
-//        connectionProps.put("user", configuration.getDatabaseProperties().getUsername());
-//        connectionProps.put("password", configuration.getDatabaseProperties().getPassword());
-//        //connectionProps.put("useAffectedRows", true);
-//        connectionProps.put("compensateOnDuplicateKeyUpdateCounts", true);
-//
-//
-//        Connection newConnection = DriverManager.getConnection(configuration.getDatabaseProperties().toJdbcUrl(),connectionProps);
- //       return newConnection;
-
         return DriverManager.getConnection(
-            configuration.getDatabaseProperties().toJdbcUrl(),
-            configuration.getDatabaseProperties().getUsername(),
-            configuration.getDatabaseProperties().getPassword()
+                configuration.getDatabaseProperties().toJdbcUrl(),
+                configuration.getDatabaseProperties().getUsername(),
+                configuration.getDatabaseProperties().getPassword()
         );
     }
 }

--- a/src/main/java/vott/database/seeddata/SeedData.java
+++ b/src/main/java/vott/database/seeddata/SeedData.java
@@ -125,7 +125,7 @@ public class SeedData {
         tr.setTestExpiryDate("2022-01-01");
         tr.setTestAnniversaryDate("2022-01-01");
         tr.setTestTypeStartTimestamp("2022-01-01 00:00:00");
-        tr.setTestTypeEndTimestamp("2022-01-01 00:00:00");
+        tr.setTestTypeEndTimestamp("2022-01-01 00:00:00.000");
         tr.setNumberOfSeatbeltsFitted("2");
         tr.setLastSeatbeltInstallationCheckDate("2022-01-01");
         tr.setSeatbeltInstallationCheckDate("1");

--- a/src/main/java/vott/database/sqlgeneration/SqlGenerator.java
+++ b/src/main/java/vott/database/sqlgeneration/SqlGenerator.java
@@ -40,7 +40,7 @@ public class SqlGenerator {
                         .collect(Collectors.joining(", "))
         );
 
-      System.out.println(sql);
+      //System.out.println(sql);
        return sql;
     };
 
@@ -91,7 +91,7 @@ public class SqlGenerator {
             String.join(", ", valuePlaceholders),
             String.join(", ", updatePlaceholders)
         );
-        System.out.println(sql);
+        //System.out.println(sql);
         return sql;
     }
 

--- a/src/main/java/vott/database/sqlgeneration/SqlGenerator.java
+++ b/src/main/java/vott/database/sqlgeneration/SqlGenerator.java
@@ -30,6 +30,21 @@ public class SqlGenerator {
         );
     }
 
+    public String generateSelectByFingerprint (TableDetails tableDetails) {
+
+        String sql = String.format(
+                "SELECT id FROM %s WHERE testtype_fingerprint = MD5(CONCAT_WS('|', %s))",
+                tableDetails.getTableName(),
+                Arrays.stream(tableDetails.getColumnNames())
+                        .map(c -> "IFNULL(?,'')")
+                        .collect(Collectors.joining(", "))
+        );
+
+      System.out.println(sql);
+       return sql;
+    };
+
+
     public String generateDeleteSql(TableDetails tableDetails, int primaryKey) {
         return String.format(
             "DELETE FROM `%s` WHERE `%s` = %d",
@@ -67,7 +82,7 @@ public class SqlGenerator {
         String[] valuePlaceholders = new String[tableDetails.getColumnNames().length];
         Arrays.fill(valuePlaceholders, "?");
 
-        return String.format(
+        String sql = String.format(
             "INSERT INTO `%s` (%s) VALUES (%s) ON DUPLICATE KEY UPDATE %s",
             tableDetails.getTableName(),
             Arrays.stream(tableDetails.getColumnNames())
@@ -76,6 +91,8 @@ public class SqlGenerator {
             String.join(", ", valuePlaceholders),
             String.join(", ", updatePlaceholders)
         );
+        System.out.println(sql);
+        return sql;
     }
 
     private String generateUpsertSqlWithoutID(TableDetails tableDetails) {

--- a/src/test/java/vott/database/TestResultRepositoryTest.java
+++ b/src/test/java/vott/database/TestResultRepositoryTest.java
@@ -10,7 +10,8 @@ import org.junit.runner.RunWith;
 import vott.config.VottConfiguration;
 import vott.database.connection.ConnectionFactory;
 import vott.database.seeddata.SeedData;
-import vott.models.dao.*;
+import vott.models.dao.TestResult;
+import vott.models.dao.Vehicle;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +30,6 @@ public class TestResultRepositoryTest {
     private Integer testerPK;
     private Integer vehicleClassPK;
     private Integer testTypePK;
-    private Integer testType2PK;
     private Integer preparerPK;
     private Integer identityPK;
 
@@ -74,7 +74,7 @@ public class TestResultRepositoryTest {
 
         identityRepository = new IdentityRepository(connectionFactory);
         identityPK = identityRepository.partialUpsert(SeedData.newTestIdentity());
-      
+
         deleteOnExit = new ArrayList<>();
     }
 
@@ -85,7 +85,7 @@ public class TestResultRepositoryTest {
         }
 
         vehicleRepository.delete(vehiclePK);
-        if (vehicle2PK != null){
+        if (vehicle2PK != null) {
             vehicleRepository.delete(vehicle2PK);
         }
         fuelEmissionRepository.delete(fuelEmissionPK);
@@ -93,9 +93,6 @@ public class TestResultRepositoryTest {
         testerRepository.delete(testerPK);
         vehicleClassRepository.delete(vehicleClassPK);
         testTypeRepository.delete(testTypePK);
-        if (testType2PK != null){
-            testTypeRepository.delete(testType2PK);
-        }
         preparerRepository.delete(preparerPK);
         identityRepository.delete(identityPK);
     }
@@ -104,8 +101,9 @@ public class TestResultRepositoryTest {
     @Title("VOTT-8 - AC1 - TC49 - Testing test result unique index compound key")
     @Test
     public void upsertingIdenticalTestResultReturnsSamePk() {
-        int primaryKey1 = testResultRepository.fullUpsert(SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK));
-        int primaryKey2 = testResultRepository.fullUpsert(SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK));
+
+        int primaryKey1 = testResultRepository.fullUpsertIfNotExists(SeedData.newTestTestResult(vehiclePK, fuelEmissionPK, testStationPK, testerPK, preparerPK, vehicleClassPK, testTypePK, identityPK));
+        int primaryKey2 = testResultRepository.fullUpsertIfNotExists(SeedData.newTestTestResult(vehiclePK, fuelEmissionPK, testStationPK, testerPK, preparerPK, vehicleClassPK, testTypePK, identityPK));
 
         deleteOnExit.add(primaryKey1);
         deleteOnExit.add(primaryKey2);
@@ -121,11 +119,11 @@ public class TestResultRepositoryTest {
         vehicle2.setVin("Vin Updated");
         vehicle2PK = vehicleRepository.fullUpsert(vehicle2);
 
-        TestResult tr1 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
-        TestResult tr2 = SeedData.newTestTestResult(vehicle2PK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
+        TestResult tr1 = SeedData.newTestTestResult(vehiclePK, fuelEmissionPK, testStationPK, testerPK, preparerPK, vehicleClassPK, testTypePK, identityPK);
+        TestResult tr2 = SeedData.newTestTestResult(vehicle2PK, fuelEmissionPK, testStationPK, testerPK, preparerPK, vehicleClassPK, testTypePK, identityPK);
 
-        int primaryKey1 = testResultRepository.fullUpsert(tr1);
-        int primaryKey2 = testResultRepository.fullUpsert(tr2);
+        int primaryKey1 = testResultRepository.fullUpsertIfNotExists(tr1);
+        int primaryKey2 = testResultRepository.fullUpsertIfNotExists(tr2);
 
         deleteOnExit.add(primaryKey1);
         deleteOnExit.add(primaryKey2);
@@ -137,12 +135,12 @@ public class TestResultRepositoryTest {
     @Title("VOTT-8 - AC1 - TC51 - Testing test result unique index compound key")
     @Test
     public void upsertingNewTestNumberReturnsDifferentPk() {
-        TestResult tr1 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
-        TestResult tr2 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
+        TestResult tr1 = SeedData.newTestTestResult(vehiclePK, fuelEmissionPK, testStationPK, testerPK, preparerPK, vehicleClassPK, testTypePK, identityPK);
+        TestResult tr2 = SeedData.newTestTestResult(vehiclePK, fuelEmissionPK, testStationPK, testerPK, preparerPK, vehicleClassPK, testTypePK, identityPK);
         tr2.setTestNumber("B222A111");
 
-        int primaryKey1 = testResultRepository.fullUpsert(tr1);
-        int primaryKey2 = testResultRepository.fullUpsert(tr2);
+        int primaryKey1 = testResultRepository.fullUpsertIfNotExists(tr1);
+        int primaryKey2 = testResultRepository.fullUpsertIfNotExists(tr2);
 
         deleteOnExit.add(primaryKey1);
         deleteOnExit.add(primaryKey2);
@@ -154,12 +152,12 @@ public class TestResultRepositoryTest {
     @Title("VOTT-8 - AC1 - TC52 - Testing test result unique index compound key")
     @Test
     public void upsertingNewTestResultIdReturnsDifferentPk() {
-        TestResult tr1 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
-        TestResult tr2 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
+        TestResult tr1 = SeedData.newTestTestResult(vehiclePK, fuelEmissionPK, testStationPK, testerPK, preparerPK, vehicleClassPK, testTypePK, identityPK);
+        TestResult tr2 = SeedData.newTestTestResult(vehiclePK, fuelEmissionPK, testStationPK, testerPK, preparerPK, vehicleClassPK, testTypePK, identityPK);
         tr2.setTestResultId("2222-2222-2222-2222");
 
-        int primaryKey1 = testResultRepository.fullUpsert(tr1);
-        int primaryKey2 = testResultRepository.fullUpsert(tr2);
+        int primaryKey1 = testResultRepository.fullUpsertIfNotExists(tr1);
+        int primaryKey2 = testResultRepository.fullUpsertIfNotExists(tr2);
 
         deleteOnExit.add(primaryKey1);
         deleteOnExit.add(primaryKey2);
@@ -171,12 +169,12 @@ public class TestResultRepositoryTest {
     @Title("VOTT-8 - AC1 - TC53 - Testing test result unique index compound key")
     @Test
     public void upsertingNewTestTypeEndTimestampReturnsDifferentPk() {
-        TestResult tr1 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
-        TestResult tr2 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
+        TestResult tr1 = SeedData.newTestTestResult(vehiclePK, fuelEmissionPK, testStationPK, testerPK, preparerPK, vehicleClassPK, testTypePK, identityPK);
+        TestResult tr2 = SeedData.newTestTestResult(vehiclePK, fuelEmissionPK, testStationPK, testerPK, preparerPK, vehicleClassPK, testTypePK, identityPK);
         tr2.setTestTypeEndTimestamp("2022-01-02 00:00:00");
 
-        int primaryKey1 = testResultRepository.fullUpsert(tr1);
-        int primaryKey2 = testResultRepository.fullUpsert(tr2);
+        int primaryKey1 = testResultRepository.fullUpsertIfNotExists(tr1);
+        int primaryKey2 = testResultRepository.fullUpsertIfNotExists(tr2);
 
         deleteOnExit.add(primaryKey1);
         deleteOnExit.add(primaryKey2);
@@ -188,12 +186,12 @@ public class TestResultRepositoryTest {
     @Title("VOTT-8 - AC1 - TC54 - Testing test result unique index compound key")
     @Test
     public void upsertingIdenticalIndexValuesReturnsSamePk() {
-        TestResult tr1 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
-        TestResult tr2 = SeedData.newTestTestResult(vehiclePK,fuelEmissionPK, testStationPK, testerPK,preparerPK, vehicleClassPK, testTypePK, identityPK);
+        TestResult tr1 = SeedData.newTestTestResult(vehiclePK, fuelEmissionPK, testStationPK, testerPK, preparerPK, vehicleClassPK, testTypePK, identityPK);
+        TestResult tr2 = SeedData.newTestTestResult(vehiclePK, fuelEmissionPK, testStationPK, testerPK, preparerPK, vehicleClassPK, testTypePK, identityPK);
         tr2.setTestResult("Test Fail");
 
-        int primaryKey1 = testResultRepository.fullUpsert(tr1);
-        int primaryKey2 = testResultRepository.fullUpsert(tr2);
+        int primaryKey1 = testResultRepository.fullUpsertIfNotExists(tr1);
+        int primaryKey2 = testResultRepository.fullUpsertIfNotExists(tr2);
 
         deleteOnExit.add(primaryKey1);
         deleteOnExit.add(primaryKey2);

--- a/src/test/java/vott/enquiry/RetrieveTestHistoryClientCredsTokenTest.java
+++ b/src/test/java/vott/enquiry/RetrieveTestHistoryClientCredsTokenTest.java
@@ -126,7 +126,7 @@ public class RetrieveTestHistoryClientCredsTokenTest {
 
         testResultRepository = new TestResultRepository(connectionFactory);
         tr = SeedData.newTestTestResult(vehiclePK, fuelEmissionPK, testStationPK, testerPK, preparerPK, vehicleClassPK, testTypePK, identityPK);
-        testResultPK = testResultRepository.fullUpsert(tr);
+        testResultPK = testResultRepository.fullUpsertIfNotExists(tr);
 
         customDefectRepository = new CustomDefectRepository(connectionFactory);
         cd = SeedData.newTestCustomDefect(testResultPK);
@@ -231,7 +231,7 @@ public class RetrieveTestHistoryClientCredsTokenTest {
             assertThat(testResult.getTestAnniversaryDate()).isEqualTo(tr.getTestAnniversaryDate());
             assertThat(testResult.getModificationTypeUsed()).isEqualTo(tr.getModificationTypeUsed());
             assertThat(testResult.getOdometerReadingUnits()).isEqualTo(tr.getOdometerReadingUnits());
-            assertThat(testResult.getTestTypeEndTimestamp()).isEqualTo(tr.getTestTypeEndTimestamp());
+            assertThat(testResult.getTestTypeEndTimestamp()).isEqualTo(tr.getTestTypeEndTimestamp().substring(0,19));
             assertThat(testResult.getCountryOfRegistration()).isEqualTo(tr.getCountryOfRegistration());
             assertThat(testResult.getParticulateTrapFitted()).isEqualTo(tr.getParticulateTrapFitted());
             assertThat(testResult.getReasonForCancellation()).isEqualTo(tr.getReasonForCancellation());
@@ -342,7 +342,7 @@ public class RetrieveTestHistoryClientCredsTokenTest {
             assertThat(testResult.getTestAnniversaryDate()).isEqualTo(tr.getTestAnniversaryDate());
             assertThat(testResult.getModificationTypeUsed()).isEqualTo(tr.getModificationTypeUsed());
             assertThat(testResult.getOdometerReadingUnits()).isEqualTo(tr.getOdometerReadingUnits());
-            assertThat(testResult.getTestTypeEndTimestamp()).isEqualTo(tr.getTestTypeEndTimestamp());
+            assertThat(testResult.getTestTypeEndTimestamp()).isEqualTo(tr.getTestTypeEndTimestamp().substring(0,19));
             assertThat(testResult.getCountryOfRegistration()).isEqualTo(tr.getCountryOfRegistration());
             assertThat(testResult.getParticulateTrapFitted()).isEqualTo(tr.getParticulateTrapFitted());
             assertThat(testResult.getReasonForCancellation()).isEqualTo(tr.getReasonForCancellation());
@@ -453,7 +453,7 @@ public class RetrieveTestHistoryClientCredsTokenTest {
             assertThat(testResult.getTestAnniversaryDate()).isEqualTo(tr.getTestAnniversaryDate());
             assertThat(testResult.getModificationTypeUsed()).isEqualTo(tr.getModificationTypeUsed());
             assertThat(testResult.getOdometerReadingUnits()).isEqualTo(tr.getOdometerReadingUnits());
-            assertThat(testResult.getTestTypeEndTimestamp()).isEqualTo(tr.getTestTypeEndTimestamp());
+            assertThat(testResult.getTestTypeEndTimestamp()).isEqualTo(tr.getTestTypeEndTimestamp().substring(0,19));
             assertThat(testResult.getCountryOfRegistration()).isEqualTo(tr.getCountryOfRegistration());
             assertThat(testResult.getParticulateTrapFitted()).isEqualTo(tr.getParticulateTrapFitted());
             assertThat(testResult.getReasonForCancellation()).isEqualTo(tr.getReasonForCancellation());

--- a/src/test/java/vott/enquiry/RetrieveTestHistoryImplicitTokenTest.java
+++ b/src/test/java/vott/enquiry/RetrieveTestHistoryImplicitTokenTest.java
@@ -225,7 +225,7 @@ public class RetrieveTestHistoryImplicitTokenTest {
             assertThat(testResult.getTestAnniversaryDate()).isEqualTo(tr.getTestAnniversaryDate());
             assertThat(testResult.getModificationTypeUsed()).isEqualTo(tr.getModificationTypeUsed());
             assertThat(testResult.getOdometerReadingUnits()).isEqualTo(tr.getOdometerReadingUnits());
-            assertThat(testResult.getTestTypeEndTimestamp()).isEqualTo(tr.getTestTypeEndTimestamp());
+            assertThat(testResult.getTestTypeEndTimestamp()).isEqualTo(tr.getTestTypeEndTimestamp().substring(0,19));
             assertThat(testResult.getCountryOfRegistration()).isEqualTo(tr.getCountryOfRegistration());
             assertThat(testResult.getParticulateTrapFitted()).isEqualTo(tr.getParticulateTrapFitted());
             assertThat(testResult.getReasonForCancellation()).isEqualTo(tr.getReasonForCancellation());
@@ -337,7 +337,7 @@ public class RetrieveTestHistoryImplicitTokenTest {
             assertThat(testResult.getTestAnniversaryDate()).isEqualTo(tr.getTestAnniversaryDate());
             assertThat(testResult.getModificationTypeUsed()).isEqualTo(tr.getModificationTypeUsed());
             assertThat(testResult.getOdometerReadingUnits()).isEqualTo(tr.getOdometerReadingUnits());
-            assertThat(testResult.getTestTypeEndTimestamp()).isEqualTo(tr.getTestTypeEndTimestamp());
+            assertThat(testResult.getTestTypeEndTimestamp()).isEqualTo(tr.getTestTypeEndTimestamp().substring(0,19));
             assertThat(testResult.getCountryOfRegistration()).isEqualTo(tr.getCountryOfRegistration());
             assertThat(testResult.getParticulateTrapFitted()).isEqualTo(tr.getParticulateTrapFitted());
             assertThat(testResult.getReasonForCancellation()).isEqualTo(tr.getReasonForCancellation());
@@ -448,7 +448,7 @@ public class RetrieveTestHistoryImplicitTokenTest {
             assertThat(testResult.getTestAnniversaryDate()).isEqualTo(tr.getTestAnniversaryDate());
             assertThat(testResult.getModificationTypeUsed()).isEqualTo(tr.getModificationTypeUsed());
             assertThat(testResult.getOdometerReadingUnits()).isEqualTo(tr.getOdometerReadingUnits());
-            assertThat(testResult.getTestTypeEndTimestamp()).isEqualTo(tr.getTestTypeEndTimestamp());
+            assertThat(testResult.getTestTypeEndTimestamp()).isEqualTo(tr.getTestTypeEndTimestamp().substring(0,19));
             assertThat(testResult.getCountryOfRegistration()).isEqualTo(tr.getCountryOfRegistration());
             assertThat(testResult.getParticulateTrapFitted()).isEqualTo(tr.getParticulateTrapFitted());
             assertThat(testResult.getReasonForCancellation()).isEqualTo(tr.getReasonForCancellation());


### PR DESCRIPTION
## Description

Updates to database tests following failures on RDS upgrade.  Following upgrade when no update occurs an empty result set is returned to the test, previously this was the id key for the record in NOP.  To rectify tests now do a select then upsert to ensure they have the id key used in test assertions.

Also updated connectorj dependency to latest version.

Related issue: CB2-9719 NOP RDS upgrade

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
