### PR TITLE
test: CB2-11306 Fix flaky tests

### DIFF
--- a/src/test/java/vott/documentretrieval/DownloadMotCertificateClientCredentialsTest.java
+++ b/src/test/java/vott/documentretrieval/DownloadMotCertificateClientCredentialsTest.java
@@ -205,16 +205,6 @@ public class DownloadMotCertificateClientCredentialsTest {
     }
 
     @WithTag("Vott")
-    @Title("VOTT-5 - AC1 - TC28 - DownloadTestCertificateNumericVINNumberTest")
-    @Test
-    public void DownloadTestCertificateNumericVINNumberTest() {
-        String numericVIN = "123456789";
-        Response response = DocRetrievalAPI.getMOTCertUsingVINTestNumber(numericVIN, validTestNumber, token);
-        assertEquals(404, response.statusCode());
-        assertEquals("NoSuchKey", response.asString());
-    }
-
-    @WithTag("Vott")
     @Title("VOTT-5 - AC1 - TC29 - DownloadTestCertificateVinNumberSpecialCharsTest")
     @Test
     public void DownloadTestCertificateVinNumberSpecialCharsTest() {

--- a/src/test/java/vott/documentretrieval/DownloadMotCertificateClientCredentialsTest.java
+++ b/src/test/java/vott/documentretrieval/DownloadMotCertificateClientCredentialsTest.java
@@ -198,8 +198,8 @@ public class DownloadMotCertificateClientCredentialsTest {
     @Title("VOTT-5 - AC1 - TC27 - DownloadTestCertificateVinNumberDoesntExistTest")
     @Test
     public void DownloadTestCertificateVinNumberDoesntExistTest() {
-        String invalidVIN = "T123456789";
-        Response response = DocRetrievalAPI.getMOTCertUsingVINTestNumber(invalidVIN, validTestNumber, token);
+        String nonExistingVIN = fieldGenerator.randomVin(); // Assuming random VIN number won't exist in db
+        Response response = DocRetrievalAPI.getMOTCertUsingVINTestNumber(nonExistingVIN, validTestNumber, token);
         assertEquals(404, response.statusCode());
         assertEquals("NoSuchKey", response.asString());
     }

--- a/src/test/java/vott/documentretrieval/DownloadMotCertificateImplicitTest.java
+++ b/src/test/java/vott/documentretrieval/DownloadMotCertificateImplicitTest.java
@@ -197,8 +197,8 @@ public class DownloadMotCertificateImplicitTest {
     @Title("VOTT-5 - AC1 - TC10 - Download Test Certificate Using Implicit JWT Token for a vin number that doesn't exist in db")
     @Test
     public void DownloadTestCertificateVinNumberDoesntExistTest() {
-        String invalidVIN = "T123456789";
-        Response response = DocRetrievalAPI.getMOTCertUsingVINTestNumber(invalidVIN, validTestNumber, token);
+        String nonExistingVIN = fieldGenerator.randomVin(); // Assuming random VIN number won't exist in db
+        Response response = DocRetrievalAPI.getMOTCertUsingVINTestNumber(nonExistingVIN, validTestNumber, token);
         assertEquals(404, response.statusCode());
         assertEquals("NoSuchKey", response.asString());
     }

--- a/src/test/java/vott/documentretrieval/DownloadMotCertificateImplicitTest.java
+++ b/src/test/java/vott/documentretrieval/DownloadMotCertificateImplicitTest.java
@@ -204,16 +204,6 @@ public class DownloadMotCertificateImplicitTest {
     }
 
     @WithTag("Vott")
-    @Title("VOTT-5 - AC1 - TC11 - Download Test Certificate Using Implicit JWT Token with a wrong format vin number (numeric only)")
-    @Test
-    public void DownloadTestCertificateNumericVINNumberTest() {
-        String numericVIN = "123456789";
-        Response response = DocRetrievalAPI.getMOTCertUsingVINTestNumber(numericVIN, validTestNumber, token);
-        assertEquals(404, response.statusCode());
-        assertEquals("NoSuchKey", response.asString());
-    }
-
-    @WithTag("Vott")
     @Title("VOTT-5 - AC1 - TC12 - Download Test Certificate Using Implicit JWT Token with a wrong format vin number (containing special chars)")
     @Test
     public void DownloadTestCertificateVinNumberSpecialCharsTest() {


### PR DESCRIPTION
## Description
Removed tests for numeric only VIN number as document retrieval app does not require non numeric.
Replaced hardcoded VIN numbers in some tests with randomVIN to increase the possibility of VIN number not being in the database

Related issue: [CB2-11306](https://dvsa.atlassian.net/browse/CB2-11306)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
